### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,12 @@ class PackageCustomizer {
       package: {
         options: {
           's3-bucket': {
-            usage: 'Specify a deploymentBucket Name'
+            usage: 'Specify a deploymentBucket Name',
+            type: 'string'
           },
           's3-path': {
-            usage: 'Specify a path name of deploymentBucket'
+            usage: 'Specify a path name of deploymentBucket',
+            type: 'string'
           }
         }
       }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - PackageCustomizer for "s3-bucket", "s3-path"
```